### PR TITLE
0406 알고리즘 스터디

### DIFF
--- a/규현/0406/도넛과막대그래프.java
+++ b/규현/0406/도넛과막대그래프.java
@@ -1,0 +1,94 @@
+import java.util.*;
+import java.util.Map.*;
+
+class Solution {
+    
+    
+    boolean[] visitedEdges;
+    Map<Integer,Edge> fromMap;
+
+    int d = 0;
+    int l = 0;
+    int e = 0;
+    public int[] solution(int[][] edges) {
+
+        int numberOfEdge = edges.length;
+        fromMap = new HashMap<>();
+        Set<Integer> toSet = new HashSet<>();
+        visitedEdges = new boolean[numberOfEdge];
+        Map<Integer,Integer> counter = new HashMap<>();
+        for(int i = 0; i< numberOfEdge; i++){
+            
+            int from = edges[i][0];
+            int to = edges[i][1];
+            fromMap.put(from,new Edge(i,to,fromMap.get(from)));
+            toSet.add(to);
+            counter.put(from, counter.getOrDefault(from,0)+1);
+        }
+        
+        // 그녀석 찾기
+        int him = 0;
+        for(Entry<Integer, Integer> e : counter.entrySet()){
+            if(e.getValue() >= 2 && !toSet.contains(e.getKey())){
+                him = e.getKey();
+                break;
+            }
+        }
+        
+
+        for(Edge edge = fromMap.get(him); edge != null; edge = edge.next){
+            findRoute(edge.to);
+        }
+                
+        return new int[]{him, d, l, e};
+    }
+    
+    public void findRoute(int target){
+        
+            Set<Integer> vertex = new HashSet<>();
+            // 탐색 진행
+            vertex.add(target);
+            
+            Queue<Edge> q = new ArrayDeque<>();
+            q.add(new Edge(0, target, null));
+            int edgeCount = 0;
+            
+            while(!q.isEmpty()){
+                Edge poll = q.poll();
+                
+                for(Edge e = fromMap.get(poll.to); e != null; e = e.next){
+                    if(visitedEdges[e.index]) continue;
+                    visitedEdges[e.index] = true;
+                    vertex.add(e.to);
+                    q.add(new Edge(0, e.to, null));
+                    edgeCount++;
+                }
+            }
+        
+            // 관계 파악
+            calculateVE(vertex.size(), edgeCount);
+    }
+    
+    private void calculateVE(int numberOfVertex, int numberOfEdge){
+        
+        if(numberOfVertex == numberOfEdge){
+            d++;
+        }else if(numberOfVertex -1 == numberOfEdge){
+            l++;
+        }else{
+            e++;
+        }
+    }
+    
+    static class Edge{
+        int index;
+        int to;
+        Edge next;
+        
+        public Edge(int i, int t, Edge n){
+            index = i;
+            to = t;
+            next = n;
+        }
+    }
+}

--- a/규현/0406/산모양타일링.java
+++ b/규현/0406/산모양타일링.java
@@ -1,0 +1,63 @@
+import java.util.*;
+
+class Solution {
+    
+    boolean[][] matrix;
+    int[][] dp;
+    int last;
+    final int init = -1;
+    final int mod = 10_007;
+    public int solution(int n, int[] tops) {
+        int answer = 0;
+        last = n * 2 +1;
+     
+       matrix = new boolean[2][2*n+1];
+        dp = new int [2*n +1][3];
+        
+        Arrays.fill(matrix[0], true);
+ 
+        for(int i = 0; i< n; i++){
+            if(tops[i] == 1)
+                matrix[1][ i * 2 + 1] = true;
+        }
+    
+        
+        for(int [] d : dp)
+            Arrays.fill(d, init);
+
+        answer = find(0);
+     
+        
+        return answer;
+    }
+    
+    
+    private int find(int depth){
+        
+        if(depth >= last -1){
+            return 1;
+        }
+            
+        
+        // 0, 1, 2 케이스 구하기
+        
+        if(!matrix[1][depth]){
+            dp[depth][1] = 0;
+        }
+        if(depth == last -1){
+            dp[depth][2] = 0;
+        }
+        // 0
+        int result = 0;
+        if(dp[depth][0] == init)
+            dp[depth][0] = (find(depth+1) ) % mod ;
+        if(dp[depth][1] == init ){
+            dp[depth][1] = (find(depth+1) ) % mod;
+        }
+        if(dp[depth][2] == init){
+            dp[depth][2] = (find(depth+2) ) % mod;
+        }
+        
+        return (dp[depth][0] + dp[depth][1] + dp[depth][2]) % mod;
+    }
+}


### PR DESCRIPTION
## 1. 도넛과 막대 그래프
1. 📑 사용한 알고리즘

- Graph 탐색

2. 📑 구현 방식에 대한 간략한 설명

우선 새로운 정점을 먼저 찾고, 그 정점과 연관된 정점에서 그래프를 탐색하면 되겠다고 생각했습니다. 
각 정점이 갖는 특징을 살펴보니 대략 이런 경우가 있었습니다.
- 진입차수 1, 진출차수 1
- 진입차수 0, 진출차수 1
- 진입차수 1, 진출차수 2

하지만 새로운 정점의 경우 진입차수는 0이고, 진출 차수는 2개 이상(본래 있던 그래프의 개수) 라고 생각했습니다.  그래서 진출 차수가 2 이상인 애들을 찾고, 그 중에서 진입 차수가 0인 애를 찾으려고 했습니다. (진입이 0인걸 찾고, 진출이 1보다 큰 애를 찾아도 똑같겠죠? )

위의 방법을 통해서 새로운 정점을 찾았다면, 그 새로운 정점으로부터 출발하는 Edge에 대해서 BFS를 하면서 어떤 그래프인지 파악했습니다.
그래프 조건은 문제에도 적혀있지만 식으로 쓴 조건은 아래와 같습니다.
- 도넛의 경우 : 정점 == 간선
- 라인의 경우 : 정점 -1 == 간선
- 그 외는 8자 그래프

각 케이스마다 카운팅을 해줬습니다.

## 2 산 모양 타일링
1. 📑 사용한 알고리즘

DP

2. 📑 구현 방식에 대한 간략한 설명

그냥 타일링 문제입니다. 그런데 위에 뚜껑이 있었습니다. 
그래서 뚜껑 처리를 해주려고 했습니다. 

2차원 배열을 만들어서 전체 그림을 표현해줬는데, 생각해보니 별로 의미가 없었습니다.

우선 진행한 방법은 아래와 같습니다.

2번 예제인 N = 2, tops = [0,1] 의 경우에 2차원 배열에서 뚜껑이 있으면 T 없으면 F로 표기했습니다.

  | F |   | T |  
-- | -- | -- | -- | --
T | T | T | T | T

그 다음엔 각 칸마다 경우를 나눠서 진행하려고 했습니다.

경우는 3가지로 구분했습니다.
1. 그냥 삼각형 1개 쓰기
2. 뚜껑이 있으면 위로 가기
3. 2칸 차지하기

2칸 차지의 경우, 그림 상에서는 2개로 구분되지만, 실제 계산에선 의미 없다고 생각했습니다.

위의 3가지 케이스에서 1번, 2번의 경우는 depth+1로 이동, 3번의 경우는 depth+2로 이동하도록 했고, 마지막 정점 혹은 그 이상에 도달한 케이스에 대해서 1을 리턴해, 값을 축적하도록 했습니다.

어쩔 때는 맞고, 어쩔 때는 틀리게 나오는데, 왠지 모르겠네요?? 






































































