### PR TITLE
[BOJ] 행성연결 + [BOJ] 막대 만들기

### DIFF
--- a/24-06-4주차/병헌/BOJ_16398_행성연결.java
+++ b/24-06-4주차/병헌/BOJ_16398_행성연결.java
@@ -1,0 +1,79 @@
+package boj.gold4;
+
+import java.util.*;
+import java.io.*;
+
+/**
+
+ - @author 이병헌
+ - @since 6/24/2024
+ - @see https://www.acmicpc.net/problem/
+ - @git https://github.com/Hunnibs
+ - @youtube
+ - @performance
+ - @category #
+ - @note */
+
+public class BOJ_16398 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        List<List<Info>> cost = new ArrayList<>();
+        for(int i = 0; i < N; i++){
+            cost.add(new ArrayList<>());
+        }
+
+        for(int i = 0; i < N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < N; j++){
+                if (i == j) {
+                    st.nextToken();
+                    continue;
+                }
+                cost.get(i).add(new Info(j, Integer.parseInt(st.nextToken())));
+            }
+        }
+
+        System.out.print(prim(cost));
+    }
+
+    private static long prim(List<List<Info>> cost){
+        PriorityQueue<Info> pq = new PriorityQueue<>();
+        boolean[] visited = new boolean[cost.size()];
+        pq.add(new Info(0, 0));
+
+        long sum = 0;
+        while(!pq.isEmpty()){
+            Info cur = pq.poll();
+            if(visited[cur.to]) continue;
+
+            visited[cur.to] = true;
+            sum += cur.weight;
+
+            for(Info next : cost.get(cur.to)){
+                if (visited[next.to]) continue;
+                else {
+                    pq.add(next);
+                }
+            }
+        }
+
+        return sum;
+    }
+
+    private static class Info implements Comparable<Info>{
+        int to, weight;
+
+        public Info(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return this.weight - o.weight;
+        }
+    }
+}

--- a/24-06-4주차/병헌/BOJ_28437_막대만들기.java
+++ b/24-06-4주차/병헌/BOJ_28437_막대만들기.java
@@ -1,0 +1,59 @@
+package boj.gold3;
+
+import java.util.*;
+import java.io.*;
+
+/**
+
+ - @author 이병헌
+ - @since 6/28/2024
+ - @see https://www.acmicpc.net/problem/18437
+ - @git https://github.com/Hunnibs
+ - @youtube
+ - @performance
+ - @category # Dynamic Programming
+ - @note
+ 1. 주어지는 막대 길이는 정렬된 순서로 주어지는가? -> 아마 X인것으로 추정
+ */
+
+public class BOJ_28437 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int[] nums = new int[100_001];
+        boolean[] A = new boolean[100_001];
+
+        int N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            A[Integer.parseInt(st.nextToken())] = true;
+        }
+
+        int Q = Integer.parseInt(br.readLine());
+        int[] L = new int[Q];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < Q; i++) {
+            L[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < 100_001; i++) {
+            if (A[i]) nums[i]++;
+
+            if (nums[i] == 0){
+                continue;
+            }
+
+            for (int j = 2; i * j < 100_001; j++){
+                nums[j * i] += nums[i];
+            }
+        }
+
+        for (int i = 0; i < Q; i++) {
+            sb.append(nums[L[i]]).append(" ");
+        }
+
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## 1. [행성 연결](https://www.acmicpc.net/problem/16398)
1. 📑 사용한 알고리즘
Prim 알고리즘
2. 📑 구현 방식에 대한 간략한 설명
전형적인 Minimum spannig tree에 대한 문제였습니다. 모든 트리 노드를 연결하되 가중치 최소 합이 될 수 있도록 하면 되서 첫 번째 루트 노드를 설정한 이후 연결된 노드들을 가중치를 기준으로 오름차순 정렬되는 우선순위 큐에 넣어 가장 가중치가 낮은 간선부터 탐색하도록 설계하였습니다. 
특별히 Prim 알고리즘을 사용한 이유는 최근 해당 알고리즘을 봐서 해당 방법으로 풀어봤습니다. 단, 가중치의 합이 Int 범위를 넘어갈 수 있다는 사실을 간과하고 3번째에 통과했던 문제여서 조심할 부분은 범위 정도였던 문제였습니다. 

## 2. [막대 만들기](https://www.acmicpc.net/problem/28437)
1. 📑 사용한 알고리즘
Dynamic Programming 
2. 📑 구현 방식에 대한 간략한 설명
처음엔 2차원 100_000 X 100_000 크기의 배열을 만들어 모든 수에 대해 10억 번의 연산 기준으로 1초가 아슬아슬할 것으로 생각해 시도했지만 시간 초과가 났고 이후 만들어야 할 막대 크기를 역으로 나눔으로 추적했지만 해당 방법은 어째서인지 시간초과가 발생하였습니다. 그래서 김규현 씨의 코드를 참고해 역으로 주어진 막대들에 대해 곱셈을 진행하는 방식으로 문제 해결을 시도하였고 해당 방법은 성공했습니다. 
구현 방법은 
- 100_000짜리 두 개의 배열을 만들어 놓고 주어진 막대들을 하나의 배열에 저장해놓습니다. 
- 나머지 하나의 배열에는 1 ~ 100_000까지 돌면서 주어진 막대일 경우나 주어진 막대로 만들 수 있는 경우를 추적해 계속해서 더해주었습니다. 
- 만들어야 할 막대를 방금 더해주던 배열에서 확인하면 몇 개를 만들 수 있는지 추적이 가능합니다.  