### PR TITLE
[BOJ] 28284 스터디까페

### DIFF
--- a/24-07-1주차/24_07_2주차/민우/Boj_28284_스터디까페.java
+++ b/24-07-1주차/24_07_2주차/민우/Boj_28284_스터디까페.java
@@ -1,0 +1,71 @@
+package ps;
+import java.io.*;
+import java.util.*;
+public class Boj_28284_스터디카페 {
+    static BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer token;
+    static StringBuilder sb = new StringBuilder();
+
+    static class Day implements Comparable<Day>{
+        long day;
+        boolean flag;
+        Day(long day, boolean flag){
+            this.day = day;
+            this.flag = flag;
+        }
+        public int compareTo (Day d){
+            return Long.compare(this.day, d.day);
+        }
+    }
+
+    public static void main(String[] args) throws IOException{
+        token = new StringTokenizer(bf.readLine());
+        int n ,m;
+        n = Integer.parseInt(token.nextToken());
+        m = Integer.parseInt(token.nextToken());
+
+        long [] prefix = new long [n+1];
+        token = new StringTokenizer(bf.readLine());
+        List<Long> list = new ArrayList<>();
+        for(int i = 1 ; i <= n ; i++){
+            list.add(Long.parseLong(token.nextToken()));
+        }
+        Collections.sort(list);
+        for(int i = 1; i <=n ;i++){
+            prefix[i] = prefix[i-1] + list.get(i-1);
+        }
+        // size 인원수 체크
+        // min  += prefix[size]
+        // max  += prefix[n] - prefix[n-size]
+        PriorityQueue<Day> pq = new PriorityQueue<>();
+        for(int i = 0; i < m; i++){
+            token = new StringTokenizer(bf.readLine());
+            long in;
+            long out;
+            in = Integer.parseInt(token.nextToken());
+            out = Integer.parseInt(token.nextToken());
+            pq.offer(new Day(in, true));
+            pq.offer(new Day(out+1, false));
+        }
+        int size = 0;
+        long min = 0;
+        long max = 0;
+        long now = 0;
+
+
+        while(!pq.isEmpty()){
+            Day cur = pq.poll();
+            long dayDiff = cur.day - now;
+            min += dayDiff*prefix[size];
+            max += dayDiff*(prefix[n] - prefix[n-size]);
+            now = cur.day;
+            if(cur.flag) size++;
+            else size--;
+        }
+
+        System.out.println(min + " " + max);
+
+
+    }
+
+}


### PR DESCRIPTION
## 1. [스터디까페](https://www.acmicpc.net/28284)
1. 📑 사용한 알고리즘
스위핑, 좌표압축, 누적합
2. 📑 구현 방식에 대한 간략한 설명
문제를 단순 구현으로 두고 풀게되면 시작일, 마지막일의 차이가 최대 10^9, 방이 500_000 이므로 굉장히 큰 시간복잡도가 나오게 된다.
이를 개선하기 위해 두가지 방법을 생각해 봤는데..
- 우선 50만개의 방에 대한 금액 부분이다.  그 날에 몇명이 있는지만 알게 된다면 누적합의 방법으로 그 날의 금액을 생각할 수 있다.
최소값, 최대값을 구하라고 하였지만, 인덱스를 0부터 시작하냐, 끝에서 시작하냐로 표현하면 되기 때문에 배열하나만 사용했다.
ex ) 3일차의 최소값 = prefix[3], 3일차의 최대값 = prefix[maxDay]  - prefix[maxDay - 3] 
- 두번째로는 10^9에 해당하는 날짜에 대한 축소이다.
이것을 해결하기 위해 스위핑, 자표압축이라는 개념을 도입했는데,, 간단히 말해서 10^9에 해당하는 배열을 다 그리는 것이 아니라 중요한 정보만 좌표에 표현하는 것이다. 시작일과 끝나는날을 포함한 날짜이기 때문에.. 계산 편의상 끝나는좌표는 +1 하여 저장한 후 정렬하여 하나씩 꺼내며 조건을 수행시켰다. 
시작하는날마다 방 사이즈를 1씩 증가시키고, 끝나는 날 마다 방 사이즈를 1씩 감소시키는 방법으로 그 구간에 필요한 방의 갯수를 구하였다. 구간이 갱신될 때마다 ( 현재날짜 - 이전 날짜 ) 의 길이에 해당하는 최소값, 최대값을 더하는 방법으로 구현하였다. 

