### PR TITLE
BOJ 11505 구간곱구하기 + 11870 좌표압축

### DIFF
--- a/영욱/BJ_G1_11505_구간곱구하기.java
+++ b/영욱/BJ_G1_11505_구간곱구하기.java
@@ -1,0 +1,126 @@
+package bj.g1;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * @author 김영욱
+ * @git
+ * @performance
+ * @category #세그먼트트리
+ * @note 세그먼트 트리를 쓰는 문제다.
+ * 다만 기존과 달리 합대신 곱을 써야한다.
+ * <p>
+ * 기존 트리의 값이 바뀌게 된다면
+ * 2 -> 8
+ * ex )0 120 6 20 2 3 4 5 1 2 -> 8로바꿔
+ * 0 120 6 20 2 3 4 5 1 8
+ * 0 120 6 20 8 3 4 5 1 8
+ * 0 120 24 20 8 3 4 5 1 8
+ * 0 480 24 20 8 3 4 5 1 8
+ * <p>
+ * 바꿀 숫자를 원래 숫자로 나눈 만큼 다른 것들도 곱해주면 됨
+ * <p>
+ * 2 -> 1
+ * ex )0 120 6 20 2 3 4 5 1 1
+ * 0 120 6 20 1 3 4 5 1 1
+ * 0 120 3 20 1 3 4 5 1 1
+ * 0 60 3 20 1 3 4 5 1 1
+ * * 3 -> 7
+ * * ex )0 120 14 20 2 7 4 5 1 2
+ * * 0 120 18 20 1 3 4 5 1 1
+ * * 0 120 3 20 1 3 4 5 1 1
+ * * 0 60 3 20 1 3 4 5 1 1
+ * 반례가 있네
+ * <p>
+ * 그냥 단순히 밑에서 부터 숫자 바꾸고 다시 갱신해야할듯
+ * https://www.youtube.com/watch?v=NoeQkthS57s&ab_channel=%EA%B7%B1%EA%B7%B1
+ * 세그먼트 트리 설명 잘되어 있는 영상
+ * @see https://www.acmicpc.net/problem/11505
+ * @since 2024. 07. 15
+ */
+public class BJ_G1_11505_구간곱구하기 {
+
+    static StringTokenizer tokens;
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+    static StringBuilder builder = new StringBuilder();
+
+    static int N, M, K;
+    static long[] tree;
+    static int[] nums;
+    static int MOD = 1000000007;
+
+    public static void main(String[] args) throws IOException {
+        tokens = new StringTokenizer(input.readLine());
+        N = Integer.parseInt(tokens.nextToken());
+        M = Integer.parseInt(tokens.nextToken());
+        K = Integer.parseInt(tokens.nextToken());
+
+        nums = new int[N + 1];
+        tree = new long[N * 4];
+
+        for (int i = 1; i <= N; i++) {
+            nums[i] = Integer.parseInt(input.readLine());
+        }
+        init(1, N, 1);
+
+        for (int i = 1; i <= M + K; i++) {
+            tokens = new StringTokenizer(input.readLine());
+            int flag = Integer.parseInt(tokens.nextToken());
+
+            if (flag == 1) {
+                int index = Integer.parseInt(tokens.nextToken());
+                int changeNum = Integer.parseInt(tokens.nextToken());
+
+                update(1, N, 1, index, changeNum);
+                nums[index] = changeNum;
+
+            } else if (flag == 2) {
+                int left = Integer.parseInt(tokens.nextToken());
+                int right = Integer.parseInt(tokens.nextToken());
+
+                builder.append(mul(1, N, 1, left, right)).append("\n");
+            }
+        }
+
+        System.out.println(builder);
+
+    }
+
+    private static long init(int start, int end, int index) {
+        if (start == end) {
+            tree[index] = nums[start];
+            return tree[index];
+        }
+
+        int mid = (start + end) / 2;
+        tree[index] = init(start, mid, index * 2) * init(mid + 1, end, index * 2 + 1) % MOD;
+        return tree[index];
+    }
+
+    private static long update(int start, int end, int index, int target, long diff) {
+        if (target < start || target > end) {
+            return tree[index];
+        }
+        if (start == end) {
+            tree[index] = diff;
+            return tree[index];
+        }
+        int mid = (start + end) / 2;
+
+        tree[index] = update(start, mid, index * 2, target, diff) * update(mid + 1, end, index * 2 + 1, target, diff) % MOD;
+        return tree[index];
+
+    }
+
+    private static long mul(int start, int end, int index, int left, int right) {
+        if(left > end || right < start) return 1;
+
+        if(left <= start && right >= end){
+            return tree[index];
+        }
+        int mid = (start + end) / 2;
+
+        return (mul(start, mid, index * 2, left, right) * mul(mid + 1, end, index * 2 + 1, left, right) % MOD);
+    }
+}

--- a/영욱/BJ_S2_18870_좌표압축.java
+++ b/영욱/BJ_S2_18870_좌표압축.java
@@ -1,0 +1,58 @@
+package bj.s2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * @author 김영욱
+ * @git
+ * @performance 2368ms
+ * @category #세그먼트트리
+ * @note
+ * 좌표가 주어지면 가장 낮은 숫자부터 큰 숫자까지 0부터 숫자를 매겨 출력하는 문제다.
+ * 나는 보자마자 Key:value에서 Map을, 정렬 + 중복 숫자 제거에서 TreeSet을 떠올렸고 바로 문제를 풀었다.
+ * 근데 TC가 숫자가 커서 꽤 시간이 오래걸렸다.
+ * 정답자들 보니 머지소트, 이진탐색 등을 활용하여 시간을 압축시키더라...
+ * 뭐, 애초에 자료구조 연습삼아서 한거니 만족한다.
+ * @see https://www.acmicpc.net/problem/18870
+ * @since 2024. 07. 18
+ */
+
+public class BJ_S2_18870_좌표압축 {
+
+    static StringTokenizer tokens;
+    static StringBuilder builder = new StringBuilder();
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+
+    static HashMap<Integer, Integer> dict = new HashMap<>();
+    static int N;
+    static int[] arr;
+    static TreeSet<Integer> set = new TreeSet<>();
+
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(input.readLine());
+        arr = new int[N];
+
+        int num = 0;
+        tokens = new StringTokenizer(input.readLine());
+        for (int i=0; i<N; i++) {
+            num = Integer.parseInt(tokens.nextToken());
+            arr[i] = num;
+            set.add(num);
+        }
+
+        int temp = 0;
+
+        for(int n: set) {
+            dict.put(n,temp++);
+        }
+
+        for(int n: arr) {
+            builder.append(dict.get(n)).append(" ");
+        }
+
+        System.out.println(builder);
+    }
+}


### PR DESCRIPTION
## 1. [구간곱구하기](https://www.acmicpc.net/11505)
1. 📑 사용한 알고리즘
세그먼트 트리
 2. 📑 구현 방식에 대한 간략한 설명
기존에 구간합구하기와는 다르게 숫자를 업데이트 할 경우 밑에서부터
다시 값을 경신해 주었다.

## [좌표압축](https://www.acmicpc.net/18870)
1. 📑 사용한 알고리즘
자료구조( TreeSet + HashMap )
2. 📑 구현 방식에 대한 간략한 설명
입력을 원본 배열과 Set으로 받고, Set을 돌면서 작은 숫자부터 1에 대응하도록 Map에 값을 설정 후
원본 배열을 돌면서 해당하는 숫자를 키로가진 Value를 출력하게 하였다.