### PR TITLE
add: 2458 키순서(규현)

### DIFF
--- a/규현/2458_키_순서/키순서_풀이1.java
+++ b/규현/2458_키_순서/키순서_풀이1.java
@@ -1,0 +1,142 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[] in = new int[n+1];
+        int[] out = new int[n+1];
+        Edge[] down = new Edge[n + 1];
+        Edge[] up = new Edge[n + 1];
+        Student[] students = new Student[n + 1];
+        int answer = 0;
+
+        for (int i = 1; i <= n; i++) {
+            students[i] = new Student(n);
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int f = Integer.parseInt(st.nextToken());
+            int t = Integer.parseInt(st.nextToken());
+
+            in[t]++;
+            out[f]++;
+            down[f] = new Edge(t, down[f]);
+            up[t] = new Edge(f, up[t]);
+            students[f].up[t] = true;
+        }
+
+        Queue<Integer> inque = new ArrayDeque<>();
+        for (int i = 1; i <= n ; i++) {
+            if(in[i] == 0)
+                inque.add(i);
+        }
+
+
+        // 진행하기
+
+        while(!inque.isEmpty()) {
+            Integer poll = inque.poll();
+            // poll의 next들에게 전달하기
+            for(Edge e = down[poll]; e != null; e = e.next) {
+                if(--in[e.to] == 0) {
+                    inque.add(e.to);
+                }
+                students[e.to].down(poll, students[poll].down);
+            }
+        }
+
+        Queue<Integer> outQueue = new ArrayDeque<>();
+        for (int i = 1; i <= n ; i++) {
+            if(out[i] == 0)
+                outQueue.add(i);
+        }
+
+        // 진행하기
+
+        while(!outQueue.isEmpty()) {
+            Integer poll = outQueue.poll();
+            // poll의 next들에게 전달하기
+            for(Edge e = up[poll]; e != null; e = e.next) {
+                if(--out[e.to] == 0) {
+                    outQueue.add(e.to);
+                }
+                students[e.to].up(students[poll].up);
+            }
+        }
+
+
+
+
+        for (int i = 1; i <= n ; i++) {
+            if (students[i].isKnown(n)) {
+                answer++;
+            }
+        }
+        System.out.println(answer);
+
+
+
+    }
+
+    static class Student{
+        boolean [] up;
+        boolean [] down;
+
+        public Student(int n) {
+            up = new boolean[n+1];
+            down = new boolean[n+1];
+        }
+
+        public void up(boolean [] targetUp) {
+            for (int i = 1; i <= down.length -1 ; i++) {
+                if(targetUp[i]){
+                    up[i] = true;
+                }
+            }
+        }
+
+        public void down(int index, boolean [] targetDown){
+            this.down[index] = true;
+            for (int i = 1; i <= down.length -1 ; i++) {
+                if(targetDown[i]){
+                    down[i] = true;
+                }
+            }
+        }
+
+        public boolean isKnown(int n){
+            int cnt = 0;
+            for (int i = 1; i <= n ; i++) {
+                if(up[i])
+                    cnt++;
+                if(down[i])
+                    cnt++;
+            }
+            return cnt+1 == n;
+        }
+    }
+
+    static class Edge{
+        int to;
+        Edge next;
+
+        public Edge(int to, Edge next) {
+            this.to = to;
+            this.next = next;
+        }
+    }
+
+
+
+}

--- a/규현/2458_키_순서/키순서_풀이2.java
+++ b/규현/2458_키_순서/키순서_풀이2.java
@@ -1,0 +1,66 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] matrix = new int[n + 1][n + 1];
+
+        for (int[] ints : matrix) {
+            Arrays.fill(ints, 10_0000_0000);
+        }
+
+        for (int i = 1; i <= n ; i++) {
+            matrix[i][i] = 0;
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int f = Integer.parseInt(st.nextToken());
+            int t = Integer.parseInt(st.nextToken());
+
+            matrix[f][t] = 1;
+
+        }
+
+        for (int k = 1; k <= n ; k++) {
+            for (int i = 1; i <= n ; i++) {
+                for (int j = 1; j <= n; j++) {
+                    if(matrix[i][j] > matrix[i][k] + matrix[k][j]) {
+                        matrix[i][j] = matrix[i][k] + matrix[k][j];
+                    }
+                }
+            }
+        }
+
+        int ans = 0;
+        for (int i = 1; i <= n ; i++) {
+            int cnt = 0;
+            for (int j = 1; j <= n; j++) {
+                if(matrix[i][j] < 10_0000_0000)
+                    cnt++;
+                if(matrix[j][i] < 10_0000_0000)
+                    cnt++;
+            }
+            if(cnt == n+1)
+                ans++;
+        }
+        System.out.println(ans);
+
+
+
+    }
+
+
+
+
+}


### PR DESCRIPTION
## 1. [키 순서](https://www.acmicpc.net/problem/2458)
1. 📑 사용한 알고리즘

BFS/ 플로이드 워셜


2. 📑 구현 방식에 대한 간략한 설명

우선 문제를 풀기 위해선 `키 순서를 아는 것` 이 무엇인지 정의를 했습니다.
이 문제에서는 나보다 큰 사람의 수 + 나보다 작은 사람의 수 = n-1 인 경우 자신의 키 순서를 알 수 있었습니다. 

이제부터 풀이는 나보다 큰 사람의 수와 나보다 작은 사람의 수를 알아내는 방법을 구해야 합니다.  

처음에 문제를 풀 때엔 '위상정렬이 섞인 그래프 탐색인가?' 라고 생각했습니다.

이 문제는 A와 B가 주어질 때, A가 B보다 작다는 것이 주어집니다.

이를 기반으로 나보다 키가 큰 사람을 모르는 사람과 나보다 키가 작은 사람을 모르는 사람으로 위상 정렬을 실행했습니다. (2차례 코드를 돌았음)

나보다 큰 사람을 기준으로 그래프 탐색을 진행하며, 나보다 큰 사람에게는 나보다 작은 사람 목록을 전달해줬습니다. (그냥 숫자로 체크하고 싶었는데, 중복 케이스가 나타났습니다.) 

마찬가지로 나보다 작은 사람 기준으로 그래프 탐색을 진행하며, 나보다 작은 사람에게는 나보다 큰 사람 목록을 전달해줬습니다.

모든 그래프 탐색이 종료된 후엔 나보다 큰 사람의 수 + 나보다 작은 사람의 수 == n-1  인 경우를 카운팅 해서 정답을 출력했습니다.

문제를 풀고 다른 사람의 풀이를 보니 `플로이드 워셜`로 문제를 푼다는 것을 알았습니다.

이 문제에 주어진 대로 플로이드 워셜을 진행하면 작은 사람 -> 큰 사람으로 그래프가 형성됩니다. 그래서 한 줄을 쭉 탐색하는 것은 의미가 없었습니다.

그래서 자신을 기준으로 십자로 탐색하며, 플로이드 워셜의 초기값이 아닌 값의 수를 계산해 이 수가 n+1개 (이 로직에서 자기 자신을 2번 체크함)가 된다면 키 순서를 아는 것으로 생각했습니다.

