### PR TITLE
BOJ 23300 웹브라우저2 

### DIFF
--- a/규현/23300_웹_브라우저2/23300_웹_브라우저2.java
+++ b/규현/23300_웹_브라우저2/23300_웹_브라우저2.java
@@ -1,0 +1,104 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    // B F A C
+
+    static Node backStack;
+    static Node frontStack;
+    static int cur = -1;
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < m; i++) {
+            action(br.readLine());
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(cur).append("\n");
+        printQueue(sb, backStack);
+        printQueue(sb, frontStack);
+
+        System.out.println(sb);
+
+    }
+
+    private static void printQueue(StringBuilder sb, Node node) {
+        if(node == null){
+            sb.append(-1);
+        }else {
+            while (node != null) {
+                while(node.count-->0)
+                    sb.append(node.pageNumber).append(" ");
+                node = node.next;
+            }
+        }
+        sb.append("\n");
+    }
+
+    static void action(String command){
+        StringTokenizer st = new StringTokenizer(command);
+
+        switch (st.nextToken()) {
+            case "B":
+                    if(backStack != null){
+                        frontStack = new Node(cur, frontStack);
+                        cur = backStack.pageNumber;
+                        if (--backStack.count == 0) {
+                            backStack = backStack.next;
+                        }
+                    }
+                break;
+            case "F":
+                    if(frontStack != null){
+                        if(backStack != null && backStack.pageNumber == cur){
+                            backStack.count++;
+                        }else {
+                            backStack = new Node(cur, backStack);
+                        }
+                        cur = frontStack.pageNumber;
+                        frontStack = frontStack.next;
+                       
+                    }
+                break;
+            case "A":
+                frontStack = null;
+                if (cur != -1) {
+                    if(backStack != null && backStack.pageNumber == cur){
+                        backStack.count++;
+                    }else {
+                        backStack = new Node(cur, backStack);
+                    }
+                }
+                cur = Integer.parseInt(st.nextToken());
+                break;
+            case "C":
+                Node temp = backStack;
+                while (temp != null) {
+                    temp.count = 1;
+                    temp = temp.next;
+                }
+                break;
+        }
+    }
+
+    static class Node{
+        int pageNumber;
+        int count;
+        Node next;
+
+        public Node(int pageNumber,  Node next) {
+            this.pageNumber = pageNumber;
+            this.count = 1;
+            this.next = next;
+        }
+    }
+}


### PR DESCRIPTION
## 1. [웹브라우저2 ](https://www.acmicpc.net/problem/23300)
1. 📑 사용한 알고리즘

구현, 스택, 연결리스트

2. 📑 구현 방식에 대한 간략한 설명

그냥 1등한거 자랑할려고 PR 올렸습니다.

이 문제는 웹 브라우저의 동작을 구현하는 문제입니다. 총 4가지의 연산이 있습니다.

뒤로가기, 앞으로 가기, 접속하기, 압축

뒤, 앞, 접 이 3가지는 간단한 연산이라서 설명은 패스하겠습니다.

압축하기라는 연산이 새로운데, 뒤로가기 목록에 동일한 페이지들이 연속해서 등장하면 1개만 남겨주는 연산입니다.

애초에 N이 크기가 작기 때문에 대충 풀어도 맞는 문제입니다만, 조금 더 쌈뽕하게 풀기 위해서 다음과 같은 자료구조를 만들었습니다.

count를 둬서 연속된 페이지의 수를 나타내고, 연결 리스트 형태로 만들어서 자바의 ArrayDeque나 ArrayList나 LinkedList보다조금 더 빠른 성능을 만들어보자했습니다. (ArrayDeque 보다 빠른지는 모릅니다.)

```java
  static class Node{
          int pageNumber;
          int count;
          Node next;
      }
```

그래서 핵심은 뒤로가기와 앞으로가기 연산을 위의 Node 클래스를 활용한 연결 리스트를 통해 count를 감소시키고 0이라면 next로 변경하기. 압축 연산에서는 뒤로가기 자료구조에서 순차 탐색을 하며 count를 1로 만들어주기를 했습니다.

