### PR TITLE
PR Template 문제 링크 url 수정

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## 1. [문제 제목](https://www.acmicpc.net/)
+## 1. [문제 제목](https://www.acmicpc.net/problem/)
 1. 📑 사용한 알고리즘
 
 2. 📑 구현 방식에 대한 간략한 설명


### PR DESCRIPTION
문제 제목 옆에 링크가 `https://www.acmicpc.net/`로 달려서 바로 문제 번호를 입력하면 이상한 곳으로 날아가서 `https://www.acmicpc.net/problem/` 으로 수정했습니다.