### PR TITLE
[BOJ] 조별과제

### DIFF
--- a/민우/Boj_30960_조별과제.java
+++ b/민우/Boj_30960_조별과제.java
@@ -1,0 +1,42 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    static BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer token;
+    public static void main(String[] args) throws IOException{
+        int n = Integer.parseInt(bf.readLine());
+        token = new StringTokenizer(bf.readLine());
+        int [] A = new int [n];
+        for(int i = 0; i < n ; i++){
+            A[i] = Integer.parseInt(token.nextToken());
+        }
+        Arrays.sort(A);
+
+        int[] diff = new int[n - 1];
+        for (int i = 0; i < n - 1; i++) {
+            diff[i] = A[i + 1] - A[i];
+        }
+        int [] prefixOdd = new int [n/2+1];
+        int [] prefixEven = new int [n/2 + 1];
+
+        for(int i = 0 ; i < n - 1; i += 2){
+            prefixEven[i/2+1] = prefixEven[i/2] + diff[i];
+        }
+        for(int i = 1 ; i < n - 1; i += 2){
+            prefixOdd[i/2+1] = prefixOdd[i/2] + diff[i];
+        }
+
+        int min = Integer.MAX_VALUE;
+        for (int i = 0; i < n - 2; i += 2) {
+            // 3칸짜리 시작 ~ 끝
+            int sum = A[i+2] - A[i];
+            sum += prefixEven[i/2];
+            sum += prefixOdd[n/2] - prefixOdd[(i+3)/2];
+            min = Math.min(sum,min);
+
+        }
+
+        System.out.println(min);
+
+    }
+}


### PR DESCRIPTION
## 1. [조별과제](https://www.acmicpc.net/problem/30960)
1. 📑 사용한 알고리즘
누적합, 정렬, 그리디 알고리즘
2. 📑 구현 방식에 대한 간략한 설명
홀수명의 사람을 2인1조로 나누고, 남은 한조는 3명을 만든 후 학번차이가 최소가 되도록 만드는 문제입니다.

먼저.. 정렬을 진행한 후 인접한 두명을 한조로 묶는 것이 가장 학번차이가 나지 않을 것이기 때문에 두명을 한조로 묶는 것이 중요하다고 생각하여 정렬을 진행했습니다.

하지만 3명인 조의 경우 학번이 최소인 값이 입력에 따라 달라지기 때문에 모든 경우의 수를 탐색해야 한다고 생각하고 모든 경우의 수를 돌리기 시작했습니다. 그래서 총 3부분으로 나누어 학번 계산을 하게 되는데 n의 크기가 변수가 됩니다.

[ 2 명 그룹 ] / [ 3명 그룹 ] / [ 2명 그룹 ]

3명인 그룹의 경우 해당 A[index +2] - A[index]를 해서 간단하게 구할 수 있지만, 2명의 차이의 합의 경우 한 회전에 n번의 계산이 발생해서 총 O(n^2)의 시간복잡도를 가지게 됩니다.  이를 개선하기위해 누적합을 적용시키고자 삽질을 좀 했습니다.
우선,, 각 배열의 차이 배열을 따로 만들어서 n-1의 크기를 가지는 배열을 만들었고
3명그룹 왼쪽의 계산을 하기 위한 prefixEven, 3명그룹 오른쪽 계산을 위한 prefixOdd 2개를 만들어서 n의 시간이 걸리는 차이의 합을 개선했습니다.

짝수와 홀수가 분리된 이유는 3명그룹이 홀수라서 그렇습니다.


