### PR TITLE
BOJ 두 배열의 합 & 컨베이어 벨트 위의 로봇 & 앱

### DIFF
--- a/민우/Boj_30960_조별과제.java
+++ b/민우/Boj_30960_조별과제.java
@@ -1,0 +1,42 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    static BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer token;
+    public static void main(String[] args) throws IOException{
+        int n = Integer.parseInt(bf.readLine());
+        token = new StringTokenizer(bf.readLine());
+        int [] A = new int [n];
+        for(int i = 0; i < n ; i++){
+            A[i] = Integer.parseInt(token.nextToken());
+        }
+        Arrays.sort(A);
+
+        int[] diff = new int[n - 1];
+        for (int i = 0; i < n - 1; i++) {
+            diff[i] = A[i + 1] - A[i];
+        }
+        int [] prefixOdd = new int [n/2+1];
+        int [] prefixEven = new int [n/2 + 1];
+
+        for(int i = 0 ; i < n - 1; i += 2){
+            prefixEven[i/2+1] = prefixEven[i/2] + diff[i];
+        }
+        for(int i = 1 ; i < n - 1; i += 2){
+            prefixOdd[i/2+1] = prefixOdd[i/2] + diff[i];
+        }
+
+        int min = Integer.MAX_VALUE;
+        for (int i = 0; i < n - 2; i += 2) {
+            // 3칸짜리 시작 ~ 끝
+            int sum = A[i+2] - A[i];
+            sum += prefixEven[i/2];
+            sum += prefixOdd[n/2] - prefixOdd[(i+3)/2];
+            min = Math.min(sum,min);
+
+        }
+
+        System.out.println(min);
+
+    }
+}

--- a/병헌/BOJ_01647_도시분할계획/BOJ_01647_kruskal.java
+++ b/병헌/BOJ_01647_도시분할계획/BOJ_01647_kruskal.java
@@ -1,0 +1,100 @@
+package boj.gold5.BOJ_01647_도시분할계획;
+
+/**
+
+- @author 이병헌
+- @since 8/5/24
+- @see https://www.acmicpc.net/problem/01647
+- @git https://github.com/Hunnibs
+- @youtube
+- @performance
+- @category # kruskal # union-find
+- @note
+
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_01647_kruskal {
+    private static int[] parent;
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<Info> graph = new ArrayList<>();
+
+        for (int i = 0; i < M; i++){
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph.add(new Info(a, b, c));
+        }
+
+        Collections.sort(graph);
+
+        parent = new int[N+1];
+        for (int i = 0; i <= N; i++) {
+            parent[i] = i;
+        }
+
+        long answer = 0;
+        int max = 0;
+        for(Info info : graph){
+            if (find(info.from) != find(info.to)){
+                answer += info.weight;
+                union(info.from, info.to);
+                max = Math.max(max, info.weight);
+            }
+        }
+
+        System.out.print(answer - max);
+    }
+
+    private static void union(int x, int y){
+        x = find(x);
+        y = find(y);
+
+        if (x != y){
+            if (x > y) {
+                parent[y] = x;
+            } else{
+                parent[x] = y;
+            }
+        }
+    }
+
+    private static int find(int x){
+        if (x == parent[x]){
+            return x;
+        }
+
+        return parent[x] = find(parent[x]);
+    }
+
+    private static class Info implements Comparable<Info>{
+        int from, to, weight;
+
+        public Info(int from, int to, int weight) {
+            this.from = from;
+            this.to = to;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return Integer.compare(weight, o.weight);
+        }
+    }
+}

--- a/병헌/BOJ_01647_도시분할계획/BOJ_01647_prim.java
+++ b/병헌/BOJ_01647_도시분할계획/BOJ_01647_prim.java
@@ -1,0 +1,104 @@
+package boj.gold5.BOJ_01647_도시분할계획;
+
+/**
+
+- @author 이병헌
+- @since 7/30/24
+- @see https://www.acmicpc.net/problem/1647
+- @git https://github.com/Hunnibs
+- @youtube
+- @performance
+- @category # Graph #
+- @note
+
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_01647_prim {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        Graph graph = new Graph(N);
+
+        for (int i = 0; i < M; i++){
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph.setGraph(a, b, c);
+            graph.setGraph(b, a, c);
+        }
+
+        System.out.print(prim(N, graph));
+    }
+
+    private static long prim(int N, Graph graph){
+        PriorityQueue<Info> pq = new PriorityQueue<>();
+        boolean[] visited = new boolean[N + 1];
+        pq.add(new Info(1,0));
+
+        long sum = 0;
+        int max = 0;
+        while (!pq.isEmpty()) {
+            Info cur = pq.poll();
+            if (visited[cur.to]) continue;
+
+            visited[cur.to] = true;
+            sum += cur.weight;
+            max = Math.max(max, cur.weight);
+
+            List<Info> nextGroup = graph.getGraph(cur.to);
+            for(Info next : nextGroup){
+                if (visited[next.to]) continue;
+                else pq.add(next);
+            }
+        }
+
+        return sum - max;
+    }
+
+    private static class Graph{
+        List<List<Info>> graph = new ArrayList<>();
+
+        public Graph(int N){
+            for(int i = 0; i <= N; i++){
+                graph.add(new ArrayList<>());
+            }
+        }
+
+        public void setGraph(int from, int to, int weight){
+            graph.get(from).add(new Info(to, weight));
+        }
+
+        public List<Info> getGraph(int from){
+            return graph.get(from);
+        }
+    }
+
+    private static class Info implements Comparable<Info>{
+        int to, weight;
+
+        public Info(int to, int weight){
+            this.to = to;
+            this.weight = weight;
+        }
+
+        @Override
+        public int compareTo(Info o) {
+            return this.weight - o.weight;
+        }
+    }
+}

--- a/영욱/BJ_G3_2143_두배열의합.java
+++ b/영욱/BJ_G3_2143_두배열의합.java
@@ -1,0 +1,119 @@
+package bj.g3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+/**
+ * @author 김영욱
+ * @git
+ * @performance
+ * @category #
+ * @note 두 배열 A랑 B가 주어지고 목표 숫자인 T가 주어진다
+ * A,B 배열에 있는 요소를 합쳐서 목표 숫자인 T가 되는 경우의 수를 구해라
+ * <p>
+ * T(5) = A[1] + B[1] + B[3] 이게 한 경우 (인덱스 아닌 그냥 요소를 나타냈음 합이 5인거)
+ * <p>
+ * 첫 번째 든 생각 : 각 배열에 관하여 세그먼트 트리로 구간합을 만들어 놓고 해보자!
+ * 대 실패
+ * 세그먼트 트리는 구간의 합이니까 이 문제와 맞지 않는다.
+ * 바로 검색 -> 부배열?과 투포인터
+ * 부배열은 단순 무식하게 구하는 수 밖에 없고, 여기서 까먹은 시간 복잡도를 투포인터로 커버하는 느낌의 문제였다.
+ * 이번에는 보고 풀었으니 나중에 다시 풀어보자
+ * @see https://www.acmicpc.net/problem/2143
+ * @since 2024. 08. 03
+ */
+
+public class BJ_G3_2143_두배열의합 {
+
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer tokens;
+
+    static int T, N, M;
+    static long ans;
+    static int[] A, B;
+    static ArrayList<Long> aSum;
+    static ArrayList<Long> bSum;
+
+
+    public static void main(String[] args) throws IOException {
+        T = Integer.parseInt(input.readLine());
+
+        N = Integer.parseInt(input.readLine());
+        A = new int[N + 1];
+        tokens = new StringTokenizer(input.readLine());
+        for (int i = 1; i <= N; i++) {
+            A[i] = Integer.parseInt(tokens.nextToken());
+        }
+
+        M = Integer.parseInt(input.readLine());
+        B = new int[M + 1];
+        tokens = new StringTokenizer(input.readLine());
+        for (int i = 1; i <= M; i++) {
+            B[i] = Integer.parseInt(tokens.nextToken());
+        }
+
+        aSum = new ArrayList<>();
+        bSum = new ArrayList<>();
+
+        calArraySum(aSum, A);
+        calArraySum(bSum, B);
+
+        Collections.sort(aSum);
+        Collections.sort(bSum);
+
+        int left = 0;
+        int right = bSum.size() - 1;
+
+        while (left < aSum.size() && right >= 0) { // 모든 포인터를 훑고 지나가야해서
+            long sum = aSum.get(left) + bSum.get(right);
+
+            if (sum == T) {
+                long strickA = aSum.get(left);
+                long strickB = bSum.get(right);
+                long aCnt = 0, bCnt = 0;
+                while (left < aSum.size() && aSum.get(left) == strickA) { // 전에 있던 숫자와 같은 숫자라면
+                    aCnt++;
+                    left++;
+                }
+                while (right >= 0 && bSum.get(right) == strickB) { // 전에 있던 숫자와 같은 숫자라면
+                    bCnt++;
+                    right--;
+                }
+                ans += aCnt * bCnt;
+            }
+            else if(sum > T) {
+                right--;
+            }
+            else {
+                left++;
+            }
+        }
+        System.out.println(ans);
+    }
+
+    private static void calArraySum(ArrayList<Long> sumList, int[] nums) {
+        for (int i = 1; i < nums.length; i++) {
+            long sum = 0;
+            for (int j = i; j < nums.length; j++) {
+                sum += nums[j];
+                sumList.add(sum);
+            }
+        }
+    }
+//    private static long treeInit(int start, int end, int index, long[] tree, int[] nums) {
+//        if (start == end) {
+//            tree[index] = nums[start];
+//            return tree[index];
+//        }
+//
+//        int mid = (start + end) / 2;
+//
+//        tree[index] = treeInit(start, mid, index * 2, tree, nums) + treeInit(mid + 1, end, index * 2 + 1, tree, nums);
+//        return tree[index];
+//    }
+}

--- a/영욱/BJ_G3_7579_앱.java
+++ b/영욱/BJ_G3_7579_앱.java
@@ -1,0 +1,120 @@
+package bj.g3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ @author 김영욱
+ @since 2024. 08. 07
+ @see
+ @git
+ @performance
+ @category #
+ @note
+ 시간 : 1초
+ n <= 100, 1<=M<=10,000,000
+ 새로운 앱을 실행시키기 위해 필요한 메모리가 부족해지면
+ 스마트폰의 운영체제는 활성화 되어 있는 앱들 중 몇 개를 선택하여 메모리로부터 삭제하는 수밖에 없다.
+ 이를 앱의 '비활성화'라고 하고, 나는 비활성화 문제를 해결하기 위한 프로그램을 작성해야한다.
+
+ 현재 N개의 앱이 활성화 되어있다. 이들 앱은 각각 M바이트만큼의 메모리를 사용하고 있다.
+ 앱을 비활성화한 후에 다시 실행하고자 할 경우, 추가적으로 들어가는 비용을 C라고 한다.
+ 사용자가 새로운 앱 B를 실행하고자 하여, 추가로 M바이트의 메모리가 필요하다고 하자.
+ 즉 현재 활성화 되어 있는 앱(A)들 중에서 몇 개를 비활성화하여 M바이트 이상의 메모리를
+ 추가로 확보해야 하는 것이다. 이 중에서 비활성화 했을 경우 비용 C의 합을 최소화하여
+ 필요한 메모리 M바이트를 확보하는 방법을 찾아야 한다.
+
+ 메모리 조건에 부합하면서 최소 가치의 합을 찾는 문제이다.
+ 이 문제는 메모리를 쪼갤 수 없기 때문에 0-1 KanpSack을 사용할 수 있다.
+
+ 알고리즘의 큰 틀은 다음과 같다.
+ 이번 i번째의 메모리를 비활성화 하냐 안하냐
+ 2가지 선택지 밖에 없다.
+
+ 또한 Dp는 부분 문제 해의 합들이 결국 문제의 답이 되는 특징이 있다.
+ 하지만 이 문제는 최소의 비용을 구하는 문제이기 때문에 얼핏 헷갈릴 수 있다.(내가 그랬음)
+ 배낭 문제를 접해본적이 없어서 최소 비용을 비교하며 DP테이블을 채울 수 있다고 생각했지만
+ 그런 식으로 하면 완탐이나 다름 없는 로직이 나왔다.
+
+ 반복문 구조
+ for(입력 받은 모든 앱 순회)
+ for(앱들을 비활성화 하는데 드는 비용의 합만큼 순회)
+
+ dp[현재 앱][비용] = 메모리
+
+ 현재 앱의 cost가 j보다 클 경우 끄지 못하니까 활성화시켜둔다
+ dp[i][j] = dp[i-1][j]
+
+ 그렇지 않다면 현재 앱을 끈 뒤의 byte와 그렇지 않을 경우의 byte중 큰 값을 dp에 입력한다.
+ dp[i][j] = max(byte + dp[i-1][j-cost], dp[i-1][j])
+
+
+ 반복문을 돌면서 현재 dp가 필요한 메모리보다 값이 크거나 같다면
+ 현재 드는 비용(j)과 ans를 비교해서 더 작은 값을 ans에 넣어준다.
+
+ 입력 N과 M => 앱의 개수N, 추가로 필요한 M바이트의 메모리 M
+ 각 앱A가 사용 중인 메모리 바이트 N개
+ 비활성화했을 경우 비용 C들 N개
+
+ 메모리를 가장 크게, 비용을 가장 적게 채워넣고
+ 60M 이상 중에 가장 비용이 작은 놈을 ans에 넣고 출력
+
+ 주의할 점 1. 비활성화 비용이 0인 놈도 고려해야 하기 때문에 2중 for문 시 j(cost)를 0부터 시작해야 한다.
+ 주의할 점 2. 가장 최소 비용을 뽑는다고 dp테이블에 비용을 메인으로 비교해서는 안된다.
+ ( j를 cost로 두고 제일 큰 메모리를 저장하는 방식이 합리적 )
+ */
+
+public class BJ_G3_7579_앱_2차시기 {
+
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer tokens;
+
+    static int M;
+    static int N;
+    static int ans = Integer.MAX_VALUE;
+    static int[] memory, cost;
+    static int dp[][];
+
+    public static void main(String[] args) throws IOException {
+        tokens = new StringTokenizer(input.readLine());
+        N = Integer.parseInt(tokens.nextToken());
+        M = Integer.parseInt(tokens.nextToken());
+
+        memory = new int[N+1];
+        cost = new int[N+1];
+
+        tokens = new StringTokenizer(input.readLine());
+        int sum = 0;
+        for(int i=1; i<=N; i++) {
+            memory[i] = Integer.parseInt(tokens.nextToken());
+        }
+
+        tokens = new StringTokenizer(input.readLine());
+        for(int i=1; i<=N; i++) {
+            cost[i] = Integer.parseInt(tokens.nextToken());
+            sum += cost[i];
+        }
+
+        dp = new int[N+1][sum+1];
+
+        for(int i=1; i<=N; i++) {
+            for(int j=0; j<=sum; j++) {
+                if(cost[i] > j) { // 현재 앱을 종료하는 비용보다 내가 가진 비용이 적다면
+                    dp[i][j] = dp[i-1][j];
+                }
+                else { // 현재 앱을 종료하는 비용보다 내가 가진 비용이 같거나 크다면
+                    // 지금 이 가격에 전에 물건까지 샀을 때의 비용과,
+                    // 현재 앱을 종료하고 남은 cost 중에서 살 수 있는 가장 큰 값을 더한거 중에 뭐가 더 크냐??
+                    dp[i][j] = Math.max(dp[i-1][j] , memory[i] + dp[i-1][j-cost[i]]);
+                }
+                if(dp[i][j] >= M) {
+                    ans = Math.min(ans, j);
+                }
+            }
+        }
+        System.out.println(ans);
+    }
+
+}

--- a/영욱/BJ_G5_20055_컨베이어벨트위의로봇.java
+++ b/영욱/BJ_G5_20055_컨베이어벨트위의로봇.java
@@ -1,0 +1,127 @@
+package bj.g5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+/**
+ * @author 김영욱
+ * @git
+ * @performance 1280ms
+ * @category #시뮬레이션
+ * @note 시간 : 1초
+ * 길이 N인 컨베이어 벨트가 있고, 길이 2N짜리 벨트가 위아래로 덮고 있다
+ * 1에 로봇을 올리고, N에 로봇이 하차한다.
+ * 로봇은 벨트 위에서 스스로 움직일 수 있다.
+ *
+ * 1. 벨트가 각 칸 위에 있는 로봇과 함께 한 칸 회전한다.
+ * 2. 가장 먼저 벨트에 올라간 로봇부터, 벨트가 회전하는 방향으로 한 칸 이동할 수 있다면 이동한다.
+        만약 이동할 수 없다면 가만히 있는다.
+        1.로봇이 이동하기 위해서는 이동하려는 칸에 로봇이 없으며, 그 칸의 내구도가 1 이상 남아 있어야 한다.
+ * 3. 올리는 위치에 있는 칸의 내구도가 0이 아니면 올리는 위치에 로봇을 올린다.
+ * 4. 내구도가 0인 칸의 개수가 K개 이상이라면 과정을 종료한다. 그렇지 않다면 1번으로 돌아간다.
+ *
+ * 구현 문제는 이해가 참 어려운 것 같다... 인터넷의 도움을 살짝 받았다.
+ *
+ * 처음에는 덱을 생각했으나 N의 인덱스에서 로봇이 내려야 하기 때문에 인덱스 접근이 불가능해서 실패.
+ * 원형버퍼를 생각했으나 구현하기 귀찮아서 그냥 연결리스트로 구현하였다.
+ * 자바에서 연결리스트를 사용하는 것은 처음이여서 인터넷 코드를 좀 참조하였다.
+ *
+ *
+ * @see https://www.acmicpc.net/problem/20055
+ * @since 2024. 08. 05
+ */
+
+public class BJ_G5_20055_컨베이어벨트위의로봇 {
+
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer tokens;
+
+    static int N, K;
+    static int step, zeroCnt;
+    static LinkedList<Belt> belt = new LinkedList<>();
+    public static void main(String[] args) throws IOException {
+        tokens = new StringTokenizer(input.readLine());
+        N = Integer.parseInt(tokens.nextToken());
+        K = Integer.parseInt(tokens.nextToken());
+
+        tokens = new StringTokenizer(input.readLine());
+        for(int i=0; i<2*N; i++) {
+            int health = Integer.parseInt(tokens.nextToken());
+            belt.add(i, new Belt(health));
+        }
+
+        while(zeroCnt < K) {
+            step++;
+            moveBelt();
+            moveRobot();
+            if(belt.get(0).health > 0) belt.get(0).layupRobot();
+
+//            printBelt();
+        }
+        System.out.println(step);
+    }
+
+    private static void printBelt() {
+        for(Belt now: belt) {
+            if (now.isRobot) {
+                System.out.print("(" + now.health + ") ");
+            }
+            else {
+                System.out.print(now.health + " ");
+            }
+        }
+        System.out.print(" zeroCnt : " + zeroCnt);
+        System.out.println();
+    }
+
+    private static void moveBelt() {
+        Belt lastOne = belt.removeLast();
+        belt.add(0, lastOne);
+        if(belt.get(N-1).isRobot) {
+            belt.get(N-1).isRobot = false;
+        }
+    }
+
+    private static void moveRobot() {
+//        0부터 정방향으로 로봇을 옮긴다면 벨트 위 로봇의 유뮤, 내구성이 영향을 받게됨
+        for(int i=N-2; i>=0; i--) {
+//            현재 벨트에 로봇 없으면
+            if(!belt.get(i).isRobot) continue;
+//            다음 벨트의 내구도가 0이거나 다음 벨트에 로봇이 이미 있다면
+            if(belt.get(i+1).health <= 0 || belt.get(i+1).isRobot) continue;
+
+            belt.get(i).isRobot = false;
+            belt.get(i+1).layupRobot();
+
+//            N이면 내려
+            if(i + 1 == N-1) belt.get(i+1).isRobot = false;
+        }
+    }
+
+
+    private static class Belt{
+        int health;
+        boolean isRobot;
+        boolean zeroCheck;
+
+        public Belt(int health) {
+            this.health = health;
+            isRobot = false;
+            zeroCheck = false;
+        }
+
+        public void layupRobot() {
+            isRobot = true;
+            health--;
+            if(this.health <= 0) {
+                zeroCnt++;
+                this.zeroCheck = true;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## 1. [두 배열의 합](https://www.acmicpc.net/problem/2143)
1. 📑 사용한 알고리즘
누적합(부배열), 투포인터

2. 📑 구현 방식에 대한 간략한 설명
처음에는 배열의 합?! 세그먼트 트리?!하고 별 생각 없이 했다가 크게 데이고( 구간의 합을 구하는게 아니였음 )
부배열이라는 어려운 이름의 누적합 배열을 배웠고( 1~5까지의 합, 2~5까지의 합, 3~5까지의 합), 여기서 사용한 시간 복잡도를
투포인터로 해결하는 듯한 문제였습니다.

## 2. [컨베이어 벨트 위의 로봇](https://www.acmicpc.net/problem/20055)
1. 📑 사용한 알고리즘
구현

2. 📑 구현 방식에 대한 간략한 설명
처음에는 덱을 생각했으나 N의 인덱스에서 로봇이 내려야 하기 때문에 인덱스 접근이 불가능해서 실패.
원형버퍼를 생각했으나 구현하기 귀찮아서 그냥 연결리스트로 구현하였다.
자바에서 연결리스트를 사용하는 것은 처음이여서 인터넷 코드를 좀 참조하였다.

주의할 점 1.  0이되면 count하는 로직이 있는데, 중복 체크를 할 수 있기에 belt클래스에 zeroCheck 변수를 추가하였다.
주의할 점 2. 구현, 시뮬 문제는 정말 시키는대로, 시키는 순서대로 로직을 실행해야 한다는 것을 깨달았다.
이 문제에서는 먼저 벨트를 회전 시키고, 그 후에 로봇을 옮기고( 첫 턴에는 로봇이 없음 ), 그리고 로봇을 올려 놓는 것.

## 3. [앱](https://www.acmicpc.net/problem/7579)
1. 📑 사용한 알고리즘
0-1 냅색

2. 📑 구현 방식에 대한 간략한 설명
 메모리 조건에 부합하면서 최소 가치의 합을 찾는 문제이다.
 이 문제는 메모리를 쪼갤 수 없기 때문에 0-1 KanpSack을 사용할 수 있다.

 알고리즘의 큰 틀은 다음과 같다.
 이번 i번째의 메모리를 비활성화 하냐 안하냐
 2가지 선택지 밖에 없다.

 또한 Dp는 부분 문제 해의 합들이 결국 문제의 답이 되는 특징이 있다.
 하지만 이 문제는 최소의 비용을 구하는 문제이기 때문에 얼핏 헷갈릴 수 있다.(내가 그랬음)
 배낭 문제를 접해본적이 없어서 최소 비용을 비교하며 DP테이블을 채울 수 있다고 생각했지만
 그런 식으로 하면 완탐이나 다름 없는 로직이 나왔다.

 반복문 구조
 for(입력 받은 모든 앱 순회)
 for(앱들을 비활성화 하는데 드는 비용의 합만큼 순회)

 dp[현재 앱][비용] = 메모리

 현재 앱의 cost가 j보다 클 경우 끄지 못하니까 활성화시켜둔다
 dp[i][j] = dp[i-1][j]

 그렇지 않다면 현재 앱을 끈 뒤의 byte와 그렇지 않을 경우의 byte중 큰 값을 dp에 입력한다.
 dp[i][j] = max(byte + dp[i-1][j-cost], dp[i-1][j])

 반복문을 돌면서 현재 dp가 필요한 메모리(M)보다 값이 크거나 같다면
 현재 드는 비용(j)과 ans를 비교해서 더 작은 값을 ans에 넣어준다.

 메모리를 가장 크게, 비용을 가장 적게 채워넣고
 60M 이상 중에 가장 비용이 작은 놈을 ans에 넣고 출력

 주의할 점 1. 비활성화 비용이 0인 놈도 고려해야 하기 때문에 2중 for문 시 j(cost)를 0부터 시작해야 한다.
 주의할 점 2. 가장 최소 비용을 뽑는다고 dp테이블에 비용을 메인으로 비교해서는 안된다.
 ( j를 cost로 두고 제일 큰 메모리를 저장하는 방식이 합리적 )

1년 전에 끝끝내 반례 못찾아서 못풀었던 앱 드디어 처치 완료
