### PR TITLE
BOJ 너 봄에는 캡사이신이 맛있단다, 비숍

### DIFF
--- a/민우/Boj_15824_너봄에은캡사이신이맛있단다.java
+++ b/민우/Boj_15824_너봄에은캡사이신이맛있단다.java
@@ -1,0 +1,35 @@
+package ps;
+import java.io.*;
+import java.util.*;
+public class Boj_15824_너봄에는캡사이신이맛있단다 {
+    static BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer token;
+    static private final long mod = 1_000_000_007L;
+    public static void main(String[] args) throws IOException{
+        int n = Integer.parseInt(bf.readLine());
+        token = new StringTokenizer(bf.readLine());
+        long [] arr = new long [n];
+        long [] pow = new long [n+1];
+        for(int i = 0 ; i < n ; i++){
+            arr[i] = Long.parseLong(token.nextToken());
+        }
+        pow[0] = 1;
+
+        for(int i = 1; i < n ; i++){
+            pow[i] = (pow[i-1]*2)%mod;
+        }
+        Arrays.sort(arr);
+        long ans = 0;
+
+        for(int i = 0; i < n; i++){
+            ans = (ans + (arr[i] % mod * (pow[i] - 1)) % mod) % mod;
+        }
+        for(int i = 0 ; i < n; i++){
+            ans = (ans - (arr[i] % mod * (pow[n - i - 1] - 1)) % mod + mod) % mod;
+        }
+
+
+        System.out.println(ans);
+
+    }
+}

--- a/민우/Boj_1799_비숍.java
+++ b/민우/Boj_1799_비숍.java
@@ -1,0 +1,56 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer token;
+    public static void main(String[] args) throws IOException{
+
+        int n = Integer.parseInt(bf.readLine());
+
+        int [][] map = new int [n][n];
+        boolean [] visitedRow = new boolean[21];
+        boolean [] visitedCol = new boolean[21];
+        for(int i = 0 ; i < n ; i++){
+            token = new StringTokenizer(bf.readLine());
+            for(int j = 0; j < n ; j++ ){
+                map[i][j] = Integer.parseInt(token.nextToken());
+            }
+        }
+        int ans = 0;
+        max = 0;
+        dfs(map,0,0,visitedRow,visitedCol,true);
+        ans += max;
+
+        max = 0;
+        dfs(map,0,0,visitedRow,visitedCol,false);
+
+        ans += max;
+        System.out.println(ans);
+    }
+    private static int max = Integer.MIN_VALUE;
+    private static void dfs(int [][] map, int pos, int count, boolean [] visitedRow , boolean [] visitedCol, boolean color){
+        int size = map.length;
+        if(pos >= size*size) return;
+
+        for(int i = pos; i < size*size; i++){
+            int x = i%size;
+            int y = i/size;
+            if(color && (x+y)%2 != 0)continue;
+            if(!color && (x+y)%2 == 0) continue;
+
+            if(map[y][x] == 0) continue;
+            if(visitedRow[x+y])continue;
+            if(visitedCol[y-x+size]) continue;
+            visitedRow[x + y] = true;
+            visitedCol[y-x + size] = true;
+            max = Math.max(max, count + 1);
+            dfs(map,i + 1 , count + 1,visitedRow,visitedCol, color);
+            visitedRow[x + y] = false;
+            visitedCol[y - x + size] = false;
+
+
+        }
+    }
+
+}


### PR DESCRIPTION
## 1. [너 봄에는 캡사이신이 맛있단다.](https://www.acmicpc.net/problem/15824)
1. 📑 사용한 알고리즘
경우의수 구하기, 정렬
2. 📑 구현 방식에 대한 간략한 설명
모든 음식의 조합의 최대값과 최소값의 차이를 더하는 문제입니다.
저는 이문제를 다른 관점에서 보았는데,, 하나의 음식이 최소가 되는 경우의 수를 구하고 그 갯수* 스코빌지수 만큼 빼주고
하나의 음식이 최대값이 되는 경우의 수를 구하고 그 갯수* 스코빌지수 만큼 더해주는 방식을 사용해서 문제를 풀어 봤습니다 .

---

1. 최소, 최대의 경우의 수를 고려하기 위해선 정렬을 수행해야 합니다.
2. 최소와 최대를 빼줍니다.
- 고른 음식이 최소 스코빌지수인 경우
   음식이 최소 스코빌지수인 경우, 해당음식을 선택한 상태에서 그 음식의 오른쪽의 음식들에 대해 2가지 선택들을 할 수 있습니다 (선택한다, 안한다 ). 총 2^(오른쪽 음식 갯수) 개의 경우의 수가 발생하는데, 모두 선택안하는 경우는 빼야 해서 -1를 해준 후 계산했습니다.
- 고른 음식이 최대 스코빌 지수인 경우
    음식이 최대 스코빌지수인 경우, 해당음식을 선택한 상태에서 그 음식의 왼쪽의 음식들에 대한 2가지 선택들을 할 수 있습니다 (선택한다, 안한다). 총 2^(왼쪽 음식 갯수) 개의 경우의 수가 발생한느데, 모두 선택안하는 경우는 빼야해서 -1를 해주었습니다.
2-1. 최대 2^n을 곱하게 되는 상황이 발생하게 되는데, 이 부분을 해결하기 위해 배열을 하나 만들고 bottom-up 방식으로 2배씩 곱해서 사용했습니다. 각각의 연산마다 moduler를 적용한 값을 배열에 저장하고 사용했습니다.

ps : 모듈러 연산과정에서 실수가 많이 발생하니 주의해서 풀면 좋을 것 같습니다.

## 2. [비숍](https://www.acmicpc.net/problem/1799)
1. 📑 사용한 알고리즘
백트래킹, n - queen 
2. 📑 구현 방식에 대한 간략한 설명
처음에는 N-Queen 의 대각선 버전이 아닌가? 라는 생각으로 접근해서 모든 경우의 수를 구했습니다. 하지만 결과는 시간초과가 나왔습니다. 최대 10*10의 모든 칸에 비숍을 넣고, 확인하는 작업을 거치게 될 경우, 2^100의 시간복잡도를 가진 풀이가 됩니다. 2^31이 20억인것을 감안하면, 말도안되게 큰 숫자가 되기 때문에 결국 답지를 보고 풀었습니다.

이 문제에서 중요한 부분은 다음과 같습니다.

- 흰색칸과 검은색칸의 비숍은 간섭하지 않는다.
-  / 모양의 대각선은 ( row + col )의 값을 통해 사용 여부를 확인할 수 있다.
-  \ 모양의 대각선은 (row - col + n ) 의 값을 통해 사용 여부를 확인할 수 있다.

해당 조건을 바탕으로 문제풀이를 하게 되면,
흰색칸만을 다루는 백트래킹 하나와 검은색 칸만 다루는 백트래킹 하나 총 두가지를 돌리게 되어 시간복잡도가 
2^25 + 2^25 으로 단축되게 됩니다. 

사용 가능한 칸인지 체크는 두 대각선 모양의 배열을 사용하여 구현한다면 상수 시간으로 확인이 가능합니다.

비숍이라는 특징이 2^100이라는 큰값을 2^26이라는 작은값으로 바뀔 수 있다는게 정말 신기했습니다... 문제풀이 어렵군요..